### PR TITLE
Use channels rather than atomic ints for work finders

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -16,13 +16,15 @@ func LoadHandlers(store hawk.CredentialStore, hostPort string, database *sql.DB)
 
 	googleProvider := &googlecloud.GoogleProvider{}
 	worker := DiscoveryWorker{[]provider.Provider{googleProvider}, applicationsGateway}
-	finder := DiscoveryWorkFinder{Gateway: integrationsGateway}
+	finder := NewDiscoveryWorkFinder(integrationsGateway)
 
 	applicationsHandler := ApplicationsHandler{applicationsGateway}
 	integrationsHandler := IntegrationsHandler{integrationsGateway, worker}
 
 	list := []workflowsupport.Worker{&worker}
 	scheduler := workflowsupport.NewScheduler(&finder, list, 60_000)
+
+	Report(finder.Results)
 
 	return func(router *mux.Router) {
 		router.HandleFunc("/applications", hawksupport.HawkMiddleware(applicationsHandler.List, store, hostPort)).Methods("GET")

--- a/pkg/workflowsupport/workflow_support.go
+++ b/pkg/workflowsupport/workflow_support.go
@@ -13,6 +13,7 @@ type WorkFinder interface {
 	FindRequested() []interface{}
 	MarkCompleted()
 	MarkErroneous()
+	Stop()
 }
 
 type WorkScheduler struct {
@@ -72,5 +73,6 @@ func (ws *WorkScheduler) checkForWork(worker Worker) {
 
 func (ws *WorkScheduler) Stop() {
 	ws.done <- true
+	ws.Finder.(WorkFinder).Stop()
 	log.Printf("Scheduler stopped.\n")
 }


### PR DESCRIPTION
Signed-off-by: Tyson Gern <tyson@initialcapacity.io>