### PR TITLE
Remove unknown apps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ maintainers.
 * Avoid mocking HTTP tests
 * Local unit, integration, and acceptance tests should run within a few seconds, not minutes
 * Refactor ruthlessly
+* Use "query" for non-database generated identifier fields, use "queryRow" for database generated or expected identifier fields (pk, fk, etc)
 
 ### Create a new provider
 

--- a/pkg/orchestrator/applications_gateway.go
+++ b/pkg/orchestrator/applications_gateway.go
@@ -20,7 +20,7 @@ type ApplicationsDataGateway struct {
 
 func (gateway ApplicationsDataGateway) CreateIfAbsent(integrationId string, objectId string, name string, description string, service string) (string, error) {
 	existing, _ := gateway.FindByObjectId(objectId)
-	if existing.ObjectId != "" {
+	if existing != nil {
 		log.Println("Found existing application record.")
 		return existing.ID, nil
 	}
@@ -50,24 +50,45 @@ func (gateway ApplicationsDataGateway) Find() ([]ApplicationRecord, error) {
 	return records, nil
 }
 
-func (gateway ApplicationsDataGateway) FindByIntegrationId(integrationId string) (ApplicationRecord, error) {
+func (gateway ApplicationsDataGateway) FindByIntegrationId(integrationId string) (*ApplicationRecord, error) {
 	s := "select id, integration_id, object_id, name, description, service from applications where integration_id=$1"
 	return gateway.queryRow(s, integrationId)
 }
 
-func (gateway ApplicationsDataGateway) FindByObjectId(objectId string) (ApplicationRecord, error) {
+func (gateway ApplicationsDataGateway) FindByObjectId(objectId string) (*ApplicationRecord, error) {
 	s := "select id, integration_id, object_id, name, description, service from applications where object_id=$1"
-	return gateway.queryRow(s, objectId)
+	return gateway.query(objectId, s)
 }
 
-func (gateway ApplicationsDataGateway) FindById(id string) (ApplicationRecord, error) {
+func (gateway ApplicationsDataGateway) FindById(id string) (*ApplicationRecord, error) {
 	s := "select id, integration_id, object_id, name, description, service from applications where id=$1"
 	return gateway.queryRow(s, id)
 }
 
-func (gateway ApplicationsDataGateway) queryRow(sql string, id string) (ApplicationRecord, error) {
+func (gateway ApplicationsDataGateway) DeleteById(id string) error {
+	s := "delete from applications where id=$1"
+	_, err := gateway.DB.Exec(s, id)
+	return err
+}
+
+func (gateway ApplicationsDataGateway) queryRow(sql string, id string) (*ApplicationRecord, error) {
 	row := gateway.DB.QueryRow(sql, id)
 	var record ApplicationRecord
 	err := row.Scan(&record.ID, &record.IntegrationId, &record.ObjectId, &record.Name, &record.Description, &record.Service)
-	return record, err
+	return &record, err
+}
+
+func (gateway ApplicationsDataGateway) query(objectId string, s string) (*ApplicationRecord, error) {
+	rows, queryErr := gateway.DB.Query(s, objectId)
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer rows.Close()
+
+	var record ApplicationRecord
+	if rows.Next() {
+		err := rows.Scan(&record.ID, &record.IntegrationId, &record.ObjectId, &record.Name, &record.Description, &record.Service)
+		return &record, err
+	}
+	return nil, nil
 }

--- a/pkg/orchestrator/applications_gateway_test.go
+++ b/pkg/orchestrator/applications_gateway_test.go
@@ -93,3 +93,16 @@ func TestFindAppById(t *testing.T) {
 		assert.Equal(t, "aService", record.Service)
 	})
 }
+
+func TestDeleteAppById(t *testing.T) {
+	testsupport.WithSetUp(&applicationsTestData{}, func(data *applicationsTestData) {
+		id, _ := data.gateway.CreateIfAbsent(data.integrationTestId, "anObjectId", "aName", "aDescription", "aService")
+
+		err := data.gateway.DeleteById(id)
+
+		assert.NoError(t, err)
+		record, err := data.gateway.FindById(id)
+		assert.Error(t, err)
+		assert.Empty(t, record)
+	})
+}


### PR DESCRIPTION
Fixes #238 

This PR removes applications from our database that had once been discovered via an integration but no longer exists in the integration platform.

Steps to reproduce:
1. Run an integration discovery.
2. It finds App1, App2. Now we have two apps.
3. Delete App1 from the integration platform. That is, delete the app from Google or Azure platform.
4. Run the same integration discovery again or wait (_unsure of how often the discovery worker runs_).
5. Notice that we only have App2 and that App1 has been removed from our UI and database.