### PR TITLE
Add pipeline for hexa demos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,11 +94,15 @@ jobs:
           credentials_json: '${{ secrets.HEXA_DEMO_GOOGLE_CREDENTIALS }}'
       - name: 'set up cloud sdk'
         uses: 'google-github-actions/setup-gcloud@v0'
-      - id: 'gcloud'
-        name: 'build and store hexa demo image'
+      - name: 'build and store hexa demo image'
         run: |-
           gcloud builds submit --pack image=gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }},builder=heroku/buildpacks:20
           gcloud container images add-tag gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }} gcr.io/hexa-orchestration/hexa-demos:latest
+      - name: 'build opa for gcloud'
+        run: |-
+          cd deployments/opa-server
+          gcloud builds submit --tag gcr.io/hexa-orchestration/opa:${{ github.sha }}
+          gcloud container images add-tag gcr.io/hexa-orchestration/opa:${{ github.sha }} gcr.io/hexa-orchestration/opa:latest
   google-deploy-hexa-demos:
     runs-on: ubuntu-latest
     needs: [ google-container ]
@@ -110,8 +114,7 @@ jobs:
           credentials_json: '${{ secrets.HEXA_DEMO_GOOGLE_CREDENTIALS }}'
       - name: 'set up cloud sdk'
         uses: 'google-github-actions/setup-gcloud@v0'
-      - id: 'gcloud'
-        name: 'gcloud'
+      - name: 'deploy hexa-demo to cloud run'
         run: |-
           gcloud run deploy hexa-demo --image gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }} --region us-central1 --platform managed --command=demo
   google-deploy-opa:
@@ -125,10 +128,9 @@ jobs:
           credentials_json: '${{ secrets.HEXA_DEMO_GOOGLE_CREDENTIALS }}'
       - name: 'set up cloud sdk'
         uses: 'google-github-actions/setup-gcloud@v0'
-      - id: 'gcloud'
-        name: 'gcloud'
+      - name: 'deploy opa to cloud run'
         run: |-
-          gcloud run deploy hexa-opa --image openpolicyagent/opa --region us-central1 --platform managed --command="run --server --addr :8080"
+          gcloud run deploy opa --image gcr.io/hexa-orchestration/opa:${{ github.sha }} --region us-central1 --platform managed
 
   azure-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,22 +79,7 @@ jobs:
           cd deployments/opa-server
           docker build -t $ECR_REGISTRY/hexa-demo/hexa-opa-server:${{ github.sha }} .
           docker push $ECR_REGISTRY/hexa-demo/hexa-opa-server:${{ github.sha }}
-  azure-container:
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azure/docker-login@v1
-        with:
-          login-server: azurehexa.azurecr.io
-          username: ${{ secrets.HEXA_DEMO_AZURE_REGISTRY_USERNAME }}
-          password: ${{ secrets.HEXA_DEMO_AZURE_REGISTRY_PASSWORD }}
-      - name: pack
-        run: |
-          sudo add-apt-repository ppa:cncf-buildpacks/pack-cli
-          sudo apt-get update
-          sudo apt-get install -y pack-cli
-          pack build --builder heroku/buildpacks:20 --publish ${{ secrets.HEXA_DEMO_AZURE_REPOSITORY_URI }}:${{ github.sha }}
+
   google-container:
     runs-on: ubuntu-latest
     needs: [ test ]
@@ -114,7 +99,38 @@ jobs:
         run: |-
           gcloud builds submit --pack image=gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }},builder=heroku/buildpacks:20
           gcloud container images add-tag gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }} gcr.io/hexa-orchestration/hexa-demos:latest
+  google-deploy-hexa-demos:
+    runs-on: ubuntu-latest
+    needs: [ google-container ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'authenticate to google cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.HEXA_DEMO_GOOGLE_CREDENTIALS }}'
+      - name: 'set up cloud sdk'
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - id: 'gcloud'
+        name: 'gcloud'
+        run: |-
+          gcloud run deploy hexa-demo --image gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }} --region us-central1 --platform managed --command=demo
 
+  azure-container:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/docker-login@v1
+        with:
+          login-server: azurehexa.azurecr.io
+          username: ${{ secrets.HEXA_DEMO_AZURE_REGISTRY_USERNAME }}
+          password: ${{ secrets.HEXA_DEMO_AZURE_REGISTRY_PASSWORD }}
+      - name: pack
+        run: |
+          sudo add-apt-repository ppa:cncf-buildpacks/pack-cli
+          sudo apt-get update
+          sudo apt-get install -y pack-cli
+          pack build --builder heroku/buildpacks:20 --publish ${{ secrets.HEXA_DEMO_AZURE_REPOSITORY_URI }}:${{ github.sha }}
   azure-deploy-hexa-demo:
       runs-on: ubuntu-latest
       needs: [azure-container]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,18 +95,38 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pack-cli
           pack build --builder heroku/buildpacks:20 --publish ${{ secrets.HEXA_DEMO_AZURE_REPOSITORY_URI }}:${{ github.sha }}
-  azure-deploy-hexa-demo:
+  google-container:
     runs-on: ubuntu-latest
-    needs: [azure-container]
+    needs: [ test ]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
-      - name: 'login via azure cli'
-        uses: azure/login@v1
+      - uses: actions/checkout@v3
+      - name: 'authenticate to google cloud'
+        uses: 'google-github-actions/auth@v0'
         with:
-          creds: ${{ secrets.HEXA_DEMO_AZURE_CREDENTIALS }}
-      - uses: azure/webapps-deploy@v2
-        with:
-          app-name: 'azurehexa'
-          images: 'azurehexa.azurecr.io/hexa:${{ github.sha }}'
+          credentials_json: '${{ secrets.HEXA_DEMO_GOOGLE_CREDENTIALS }}'
+      - name: 'set up cloud sdk'
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - id: 'gcloud'
+        name: 'build and store hexa demo image'
+        run: |-
+          gcloud builds submit --pack image=gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }},builder=heroku/buildpacks:20
+          gcloud container images add-tag gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }} gcr.io/hexa-orchestration/hexa-demos:latest
+
+  azure-deploy-hexa-demo:
+      runs-on: ubuntu-latest
+      needs: [azure-container]
+      steps:
+        - name: 'login via azure cli'
+          uses: azure/login@v1
+          with:
+            creds: ${{ secrets.HEXA_DEMO_AZURE_CREDENTIALS }}
+        - uses: azure/webapps-deploy@v2
+          with:
+            app-name: 'azurehexa'
+            images: 'azurehexa.azurecr.io/hexa:${{ github.sha }}'
   azure-deploy-hexa-demo-config:
     runs-on: ubuntu-latest
     needs: [azure-container]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,21 @@ jobs:
         name: 'gcloud'
         run: |-
           gcloud run deploy hexa-demo --image gcr.io/hexa-orchestration/hexa-demos:${{ github.sha }} --region us-central1 --platform managed --command=demo
+  google-deploy-opa:
+    runs-on: ubuntu-latest
+    needs: [ google-container ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'authenticate to google cloud'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.HEXA_DEMO_GOOGLE_CREDENTIALS }}'
+      - name: 'set up cloud sdk'
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - id: 'gcloud'
+        name: 'gcloud'
+        run: |-
+          gcloud run deploy hexa-opa --image openpolicyagent/opa --region us-central1 --platform managed --command="run --server --addr :8080"
 
   azure-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: 'deploy opa to cloud run'
         run: |-
-          gcloud run deploy opa --image gcr.io/hexa-orchestration/opa:${{ github.sha }} --region us-central1 --platform managed
+          gcloud run deploy hexa-demo-opa-server --image gcr.io/hexa-orchestration/opa:${{ github.sha }} --region us-central1 --platform managed
 
   azure-container:
     runs-on: ubuntu-latest

--- a/deployments/opa-server/Dockerfile
+++ b/deployments/opa-server/Dockerfile
@@ -1,4 +1,5 @@
 FROM openpolicyagent/opa:latest
+ADD config/gcp-opa-config.yaml /gcp-opa-config.yaml
 ADD config/config.yaml /config.yaml
 ENTRYPOINT ["/opa"]
 CMD ["run"]


### PR DESCRIPTION
fixes #259

Deployed hexa demo on gcp lives here: [Hexa demo on GCP](https://hexa-demo-yqghonxs3a-uc.a.run.app/)