### PR TITLE
Adds the name attribute to file input

### DIFF
--- a/internal/admin/resources/templates/integrations_new_open_policy.gohtml
+++ b/internal/admin/resources/templates/integrations_new_open_policy.gohtml
@@ -12,7 +12,7 @@
                     Add Open Policy Agent support by uploading your hexa-open-policy-agent integration configuration
                     file.
                 </p>
-                <label class="file">Choose a integration configuration file<input id="key-file" type="file"/>
+                <label class="file">Choose a integration configuration file<input id="key-file" name="key" type="file"/>
                 </label>
                 <p id="key-file-name"></p>
             </fieldset>


### PR DESCRIPTION
Following instructions on the project README - [Example Workflow](https://github.com/hexa-org/policy-orchestrator#example-workflow)

When you upload the integration.json and hit Install Cloud Provider button, an error is shown
`Something went wrong. Missing key file.`

Expected: The OPA provider should be installed and no error shown.
